### PR TITLE
Fix atom feed using CDATA

### DIFF
--- a/templates/post.atom
+++ b/templates/post.atom
@@ -3,5 +3,5 @@
         <link href="https://news.do1g.com/#{{ datetime | datetime-to-slug }}" />
         <id>{{ datetime | atom-tag }}</id>
         <updated>{{ datetime | atom-datetime }}</updated>
-        <content>{{ text }}</content>
+        <content type="html"><![CDATA[{{ text }}]]></content>
     </entry>


### PR DESCRIPTION
I noticed the atom feed was not working and then tried to [validate](https://validator.w3.org/feed/) it. It seemed the HTML wanted to be escaped or something and I knew that [Alex's atom feed](https://alexwlchan.net/atom.xml), which I looked at while making my own, had html in the content. So I did what she did and added `<![CDATA[]]>` (after looking up what it did).

I don't know if this parses in Thunderbird, but it validates now so that's cool!

EDIT: Oh there's a deploy preview that's great! Thunderbird is happy now, but it's all one paragraph. 